### PR TITLE
CXX98でコンパイルするよう、明示

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -7,3 +7,4 @@ MECAB = -lmecab
 PKG_LIBS = $(MECAB)
 PKG_CPPFLAGS = -I.
 
+CXX_STD = CXX98


### PR DESCRIPTION
GCC6.1からC++14が標準となっているようで、コンパイルができません。
C++98となるようにMakevarsに追記しました。