### PR TITLE
Fix Makevars.win

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -28,7 +28,7 @@ $(SHLIB): libmecab
 
 libmecab:
 	@if [ ! -d ../mecab/win/$(FLV) ]; then mkdir -p ../mecab/win/$(FLV) ; fi
-	@if [ ! -f ../mecab/win/$(FLV)/libmecab$(WIN).tar.gz ]; then `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" -e "download.file(url='$(RMECAB_URL)$(WIN).tar.gz', destfile='../mecab/win/$(FLV)/libmecab$(WIN).tar.gz', quiet=TRUE)"`; fi
+	@if [ ! -f ../mecab/win/$(FLV)/libmecab$(WIN).tar.gz ]; then `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" -e "download.file(url='$(RMECAB_URL)', destfile='../mecab/win/$(FLV)/libmecab$(WIN).tar.gz', quiet=TRUE)"`; fi
 	@tar xfz ../mecab/win/$(FLV)/libmecab$(WIN).tar.gz 
 	@if [ ! -d ../inst ]; then mkdir -p ../inst; fi
 	@if [ ! -d ../inst/libs/$(FLV) ]; then mkdir -p ../inst/libs/$(FLV); fi

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -28,7 +28,8 @@ $(SHLIB): libmecab
 
 libmecab:
 	@if [ ! -d ../mecab/win/$(FLV) ]; then mkdir -p ../mecab/win/$(FLV) ; fi
-	@if [ ! -f ../mecab/win/$(FLV)/libmecab$(WIN).tar.gz ]; then `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" -e "download.file(url='$(RMECAB_URL)$(WIN).tar.gz', destfile='../mecab/win/$(FLV)/libmecab$(WIN).tar.gz', quiet=TRUE)"`; tar xfz ../mecab/win/$(FLV)/libmecab$(WIN).tar.gz ; fi
+	@if [ ! -f ../mecab/win/$(FLV)/libmecab$(WIN).tar.gz ]; then `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" -e "download.file(url='$(RMECAB_URL)$(WIN).tar.gz', destfile='../mecab/win/$(FLV)/libmecab$(WIN).tar.gz', quiet=TRUE)"`; fi
+	@tar xfz ../mecab/win/$(FLV)/libmecab$(WIN).tar.gz 
 	@if [ ! -d ../inst ]; then mkdir -p ../inst; fi
 	@if [ ! -d ../inst/libs/$(FLV) ]; then mkdir -p ../inst/libs/$(FLV); fi
-	@cp -rfp libmecab$(WIN)$(SHLIB_EXT) ../inst/libs/$(FLV)/libmecab$(SHLIB_EXT)
+	@cp -rfp libmecab$(SHLIB_EXT) ../inst/libs/$(FLV)/libmecab$(SHLIB_EXT)


### PR DESCRIPTION
Windows (64bit) ですが、ソースからインストールしようとすると64bit向けのlibmecab.dllが正しく展開されないためインストールに失敗します。さしあたり以下でビルドできるようにMakevars.winを修正しました。

```r
Sys.setenv(RMECAB_URL = "https://github.com/junhewk/RcppMeCab/raw/master/mecab/win/x64/mecab64_ja.tar.gz")
remotes::install_github("paithiov909/RMeCab")
```

ただ、IshidaMotohiro/RMeCabはDESCRIPTIONにライセンスが記載されているものの、リポジトリにはライセンスファイルが含まれていないため、オープンソースとして修正を提案することがはばかられます。プルリクエストをdraftとして出しますので、ライセンスを明示してください。
