### PR TITLE
単語頻度の重みづけの修正

### DIFF
--- a/R/docDF.R
+++ b/R/docDF.R
@@ -148,9 +148,9 @@ docDF <-
                                         #dtm <- dtm * globalIDF2(dtm)
         }else if(argW[i] == "idf3"){
           if(type == 0){
-            dtm[,(colN+1):ncol(dtm)]  <-   dtm[,(colN+1):ncol(dtm)]*globalIDF2(dtm[, (colN+1):ncol(dtm)])
+            dtm[,(colN+1):ncol(dtm)]  <-   dtm[,(colN+1):ncol(dtm)]*globalIDF3(dtm[, (colN+1):ncol(dtm)])
           }else{
-            dtm[,(colN+3):ncol(dtm)]  <-   dtm[,(colN+3):ncol(dtm)]*globalIDF2(dtm[, (colN+3):ncol(dtm)])
+            dtm[,(colN+3):ncol(dtm)]  <-   dtm[,(colN+3):ncol(dtm)]*globalIDF3(dtm[, (colN+3):ncol(dtm)])
           }
                                         #dtm <- dtm * globalIDF2(dtm)
         }else if(argW[i] == "idf4"){

--- a/R/docMatrix.R
+++ b/R/docMatrix.R
@@ -114,7 +114,7 @@ docMatrix <-
         }else if(argW[i] == "idf2"){
           dtm <- dtm * globalIDF2(dtm)
         }else if(argW[i] == "idf3"){
-          dtm <- dtm * globalIDF2(dtm)
+          dtm <- dtm * globalIDF3(dtm)
         }else if(argW[i] == "idf4"){
           dtm <- dtm * globalEntropy(dtm)
         } else if(argW[i] == "norm"){

--- a/R/docMatrix2.R
+++ b/R/docMatrix2.R
@@ -106,7 +106,7 @@ docMatrix2 <-
         }else if(argW[i] == "idf2"){
           dtm <- dtm * globalIDF2(dtm)
         }else if(argW[i] == "idf3"){
-          dtm <- dtm * globalIDF2(dtm)
+          dtm <- dtm * globalIDF3(dtm)
         }else if(argW[i] == "idf4"){
           dtm <- dtm * globalEntropy(dtm)
         } else if(argW[i] == "norm"){

--- a/R/docMatrixDF.R
+++ b/R/docMatrixDF.R
@@ -95,7 +95,7 @@ docMatrixDF <-
       }else if(argW[i] == "idf2"){
         dtm <- dtm * globalIDF2(dtm)
       }else if(argW[i] == "idf3"){
-        dtm <- dtm * globalIDF2(dtm)
+        dtm <- dtm * globalIDF3(dtm)
       }else if(argW[i] == "idf4"){
         dtm <- dtm * globalEntropy(dtm)
       } else if(argW[i] == "norm"){

--- a/R/docNgram2.R
+++ b/R/docNgram2.R
@@ -95,7 +95,7 @@ docNgram2 <-
         }else if(argW[i] == "idf2"){
           dtm <- dtm * globalIDF2(dtm)
         }else if(argW[i] == "idf3"){
-          dtm <- dtm * globalIDF2(dtm)
+          dtm <- dtm * globalIDF3(dtm)
         }else if(argW[i] == "idf4"){
           dtm <- dtm * globalEntropy(dtm)
         } else if(argW[i] == "norm"){

--- a/R/docNgramDF.R
+++ b/R/docNgramDF.R
@@ -107,7 +107,7 @@ docNgramDF <-
         }else if(argW[i] == "idf2"){
           dtm <- dtm * globalIDF2(dtm , tp =1)
         }else if(argW[i] == "idf3"){
-          dtm <- dtm * globalIDF2(dtm , tp =1)
+          dtm <- dtm * globalIDF3(dtm , tp =1)
         }else if(argW[i] == "idf4"){
           dtm <- dtm * globalEntropy(dtm , tp =1)
         } else if(argW[i] == "norm"){

--- a/R/weights.R
+++ b/R/weights.R
@@ -17,9 +17,9 @@ entropy <-
     if(tp == 1){
       # m <- removeInfo ( m ) 
       gf = colSums(m, na.rm = TRUE)  # 大域的頻度 F_i
-      p = m / gf                     # 各出現頻度 / 大域頻度
+      p = t(m) / gf                     # 各出現頻度 / 大域頻度
       ndocs = nrow(m)                #文書数（行側に文章）
-      entropy = - colSums( (p*log(p)) / log(ndocs), na.rm = TRUE )
+      entropy = - rowSums( (p*log(p)) / log(ndocs), na.rm = TRUE )
     }else {
       m <- removeInfo ( m ) 
       gf = rowSums(m, na.rm = TRUE)  # 大域的頻度 F_i
@@ -110,7 +110,7 @@ globalEntropy <-
   function(m, tp=0) {
 #    m <- removeInfo ( m )
     
-    return ( (1 - entropy( m )) )
+    return ( (1 - entropy(m, tp = tp)) )
   }
 
 


### PR DESCRIPTION
こんにちは

[この自作パッケージ](https://github.com/paithiov909/gibasa)でRMeCabにおける単語頻度の重みづけの再現をしていたところ、RMeCab側の処理におかしいと思われるところを見つけたのでPRを出します。ご確認いただければ幸いです

このPRではRMeCabの次の2点を修正しています

1. `weight="idf3"`を指定したときに期待どおりに`globalIDF3`が呼ばれない点
2. 行側に文書がある（tp=1）ときのエントロピーが計算できない、列側に文書があるときと計算結果が一致しない点

2点目については、次のように計算結果が一致するように修正しています

``` r
# テスト用の文書単語行列の作成
dtm <- gibasa::gbs_tokenize(audubon::polano[5:8]) |>
    dplyr::group_by(doc_id) |>
    dplyr::count(token) |>
    tidytext::cast_sparse(doc_id, token, n) |>
    as.matrix()


# 現在のRMeCabにおけるエントロピーの計算
entropy <-
  function (m, tp = 0) {
    if (tp == 1){
      gf = colSums(m, na.rm = TRUE)  # 大域的頻度 F_i
      p = m / gf                     # 各出現頻度 / 大域頻度
      ndocs = nrow(m)          # 文書数（行側に文章）
      entropy = - colSums( (p*log(p)) / log(ndocs), na.rm = TRUE )
    } else {
      gf = rowSums(m, na.rm = TRUE)  # 大域的頻度 F_i
      p = m / gf                     # 各出現頻度 / 大域頻度
      ndocs = ncol(m)           # 文書数（列側に文章）
      entropy = - rowSums( (p*log(p)) / log(ndocs), na.rm = TRUE )
    }
    return(entropy)
  }
globalEntropy <-
    function(m, tp = 0) {
        return( (1 - entropy(m, tp = tp)) )
    }


# この場合の計算結果
identical(
    globalEntropy(t(dtm)),
    globalEntropy(dtm, tp = 1)
)
#> [1] FALSE

# このforkでの計算結果
identical(
    RMeCab::globalEntropy(t(dtm)),
    RMeCab::globalEntropy(dtm, tp = 1)
)
#> [1] TRUE
```

<sup>Created on 2022-10-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

