### PR TITLE
Rセッションのクラッシュの回避

### DIFF
--- a/src/RMeCab.h
+++ b/src/RMeCab.h
@@ -99,7 +99,7 @@ extern char  * kigoCode();
 #define CHECK(eval) if (! eval) { \
     fprintf (stderr, "Exception:%s\n", mecab_strerror (mecab)); \
     mecab_destroy(mecab); \
-    return (SEXP) -1; }
+    return (SEXP) ScalarInteger(-1); }
 ///////////////////////////////////////////////////////////////
 
 // extern "C" {


### PR DESCRIPTION
MeCab本体が何らかのエラーを返した際に, Rセッションまでクラッシュしてしまいます. CHECK マクロの返り値に不正なキャストが使われていることが原因だと思います.

ただし, 現時点ではクラッシュは回避できますが, エラー内容を表示する箇所もうまく動作していません.